### PR TITLE
ADD: /privacy page + link to it from AI twin disclosure

### DIFF
--- a/src/components/AiTwinChat.astro
+++ b/src/components/AiTwinChat.astro
@@ -82,8 +82,9 @@ const live =
       <p class="mt-3 font-mono text-[10.5px] tracking-wider text-subtle">
         Powered by OpenRouter · Llama 3.3 70B · Free tier
       </p>
-      <p class="mt-1 text-[10.5px] text-subtle">
+      <p class="mt-1 text-[12px] text-muted">
         Chats are logged (no IDs) to improve this twin.
+        <a href="/privacy" class="font-medium text-ink underline decoration-ink/40 underline-offset-2 hover:decoration-ink transition">Privacy</a>
       </p>
     </>
   ) : (

--- a/src/components/AiTwinFab.astro
+++ b/src/components/AiTwinFab.astro
@@ -54,8 +54,9 @@ const live =
         <p class="text-subtle italic">Ask my AI twin. Try: "What are you working on right now?"</p>
       </div>
 
-      <p class="px-3 pt-2 text-[10.5px] text-subtle border-t border-border bg-bg/60">
+      <p class="px-3 pt-2 text-[12px] text-muted border-t border-border bg-bg/60">
         Chats are logged (no IDs) to improve this twin.
+        <a href="/privacy" class="font-medium text-ink underline decoration-ink/40 underline-offset-2 hover:decoration-ink transition">Privacy</a>
       </p>
       <form class="flex gap-2 px-3 pb-3 pt-2 bg-bg/60" data-chat-form>
         <label class="sr-only" for="ai-twin-fab-input">Ask a question</label>

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -1,0 +1,130 @@
+---
+import Base from '@/layouts/Base.astro';
+
+const lastUpdated = '2026-04-20';
+---
+
+<Base
+  title="Privacy · Sandy Lauguico"
+  description="How chats with Sandy's AI twin are logged, stored, and deleted."
+>
+  <section class="relative">
+    <div class="max-w-page mx-auto px-5 md:px-8 py-16 md:py-20">
+      <div class="max-w-2xl">
+        <p class="font-mono text-[11px] tracking-widest uppercase text-subtle">
+          Privacy
+        </p>
+        <h1 class="mt-2 text-[28px] md:text-[34px] font-semibold tracking-tight text-ink leading-tight">
+          How chats with the AI twin are handled.
+        </h1>
+        <p class="mt-3 text-[13px] text-subtle">
+          Last updated {lastUpdated}.
+        </p>
+
+        <div class="mt-8 space-y-6 text-[15px] leading-relaxed text-muted">
+          <p>
+            The chat widget on this site runs a small AI twin scoped to my
+            work. Conversations are logged so I can see how it's being used,
+            fix bad answers, and refuse things it shouldn't respond to. This
+            page describes what's captured, where it goes, and how long it's
+            kept.
+          </p>
+
+          <div>
+            <h2 class="text-[17px] font-semibold text-ink">What's logged</h2>
+            <p class="mt-2">
+              For each chat turn: the message you typed and the twin's reply.
+              That's it. No IP addresses, no user-agent strings, no session IDs,
+              no cookies, no device fingerprints. I don't run analytics on the
+              chat itself.
+            </p>
+          </div>
+
+          <div>
+            <h2 class="text-[17px] font-semibold text-ink">Who processes it</h2>
+            <p class="mt-2">
+              Your message is sent to a Cloudflare Worker I run, which forwards
+              it to an AI model for a reply:
+            </p>
+            <ul class="mt-2 space-y-1.5 pl-5 list-disc marker:text-subtle">
+              <li>
+                <strong class="text-ink font-medium">Cloudflare Workers AI</strong>
+                (primary) running Llama 3.3 70B. Per Cloudflare's policy, they
+                don't use customer prompts or completions to train models.
+              </li>
+              <li>
+                <strong class="text-ink font-medium">OpenRouter</strong>
+                (fallback, only if Workers AI is rate-limited) running a free
+                open-weights model. Free-tier routing means the underlying
+                model host may retain prompts. I use the fallback rarely.
+              </li>
+              <li>
+                <strong class="text-ink font-medium">LangSmith</strong>
+                (LangChain, hosted in the US) stores the chat trace so I can
+                review it.
+              </li>
+            </ul>
+          </div>
+
+          <div>
+            <h2 class="text-[17px] font-semibold text-ink">Cross-border transfer</h2>
+            <p class="mt-2">
+              I'm based in the Philippines; Cloudflare, OpenRouter, and
+              LangSmith are US-hosted. Your messages leave the Philippines to
+              be processed and stored. If that's not acceptable for what you
+              want to ask, please email me instead at
+              {' '}<a href="mailto:hello@sailauguico.io" class="link-underline text-ink">hello@sailauguico.io</a>.
+            </p>
+          </div>
+
+          <div>
+            <h2 class="text-[17px] font-semibold text-ink">How long it's kept</h2>
+            <p class="mt-2">
+              LangSmith auto-deletes traces after 14 days on my current plan.
+              If I flag a specific trace for review or leave feedback on it
+              while investigating abuse or bad answers, LangSmith extends that
+              trace's retention up to 400 days. I don't maintain a separate
+              long-term copy beyond what LangSmith stores.
+            </p>
+            <p class="mt-2">
+              If you'd like your messages deleted sooner, email me (see below)
+              and I'll remove the matching traces manually.
+            </p>
+          </div>
+
+          <div>
+            <h2 class="text-[17px] font-semibold text-ink">Your rights</h2>
+            <p class="mt-2">
+              Under the Philippine Data Privacy Act, GDPR, and comparable laws,
+              you can ask me what's been logged about you, request deletion, or
+              object to processing. Since I don't collect identifiers, the only
+              way to match requests is by what you typed and roughly when. Give
+              me a phrase or a time window and I can find the trace.
+            </p>
+            <p class="mt-2">
+              To request anything:
+              {' '}<a
+                href="mailto:hello@sailauguico.io?subject=Delete%20my%20AI%20twin%20chats"
+                class="link-underline text-ink">hello@sailauguico.io</a
+              >.
+            </p>
+          </div>
+
+          <div>
+            <h2 class="text-[17px] font-semibold text-ink">Contact</h2>
+            <p class="mt-2">
+              Sandy Lauguico, Manila, Philippines.
+              {' '}<a href="mailto:hello@sailauguico.io" class="link-underline text-ink">hello@sailauguico.io</a>.
+            </p>
+          </div>
+        </div>
+
+        <div class="mt-12 pt-6 border-t border-border">
+          <a href="/" class="text-[13px] text-subtle hover:text-ink transition link-underline">
+            ← Back to portfolio
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+</Base>


### PR DESCRIPTION
Discloses what is logged (messages + replies, no IDs), processors (Cloudflare Workers AI primary, OpenRouter free fallback, LangSmith US for traces), cross-border transfer to the US, LangSmith's 14-day base retention with auto-upgrade to 400 days on flagged traces, and a mailto link for deletion requests.

Also bumps the chat disclosure from 10.5px to 12px and adds a visible Privacy link after the notice so the path to the page is obvious.