### PR TITLE
ADD: AI twin hardening round 2 (NSFW/insult prefilter, coffee CTA, wa…

### DIFF
--- a/src/components/AiTwinChat.astro
+++ b/src/components/AiTwinChat.astro
@@ -43,7 +43,7 @@ const live =
         aria-live="polite"
         aria-atomic="false"
       >
-        <p class="text-subtle italic">Try: "What are you working on right now?"</p>
+        <p class="text-subtle italic">Try: "What relevant experience do you have?"</p>
       </div>
 
       <form class="mt-3 flex gap-2" data-chat-form>
@@ -80,7 +80,7 @@ const live =
       </form>
 
       <p class="mt-3 font-mono text-[10.5px] tracking-wider text-subtle">
-        Powered by OpenRouter · Llama 3.3 70B · Free tier
+        Powered by Cloudflare Workers AI · Llama 3.3 70B (OpenRouter fallback)
       </p>
       <p class="mt-1 text-[12px] text-muted">
         Chats are logged (no IDs) to improve this twin.
@@ -100,7 +100,11 @@ const live =
 </div>
 
 <script>
-  import { mountChat } from '@/scripts/aiTwin';
+  import { mountChat, warm } from '@/scripts/aiTwin';
   const card = document.querySelector<HTMLElement>('[data-ai-card]');
-  if (card) mountChat({ root: card, endpoint: card.dataset.endpoint ?? '' });
+  if (card) {
+    const endpoint = card.dataset.endpoint ?? '';
+    mountChat({ root: card, endpoint });
+    warm(endpoint);
+  }
 </script>

--- a/src/components/AiTwinFab.astro
+++ b/src/components/AiTwinFab.astro
@@ -51,7 +51,7 @@ const live =
         aria-live="polite"
         aria-atomic="false"
       >
-        <p class="text-subtle italic">Ask my AI twin. Try: "What are you working on right now?"</p>
+        <p class="text-subtle italic">Ask my AI twin. Try: "What relevant experience do you have?"</p>
       </div>
 
       <p class="px-3 pt-2 text-[12px] text-muted border-t border-border bg-bg/60">
@@ -97,7 +97,7 @@ const live =
 )}
 
 <script>
-  import { mountChat } from '@/scripts/aiTwin';
+  import { mountChat, warm } from '@/scripts/aiTwin';
 
   const fab = document.querySelector<HTMLElement>('[data-ai-fab]');
   if (fab) {
@@ -157,7 +157,10 @@ const live =
       toggleBtn.setAttribute('aria-expanded', String(open));
       if (toggleLabel) toggleLabel.textContent = open ? 'Close' : 'Ask my AI twin';
       reposition();
-      if (open) setTimeout(() => input?.focus(), 0);
+      if (open) {
+        warm(endpoint);
+        setTimeout(() => input?.focus(), 0);
+      }
     };
 
     toggleBtn?.addEventListener('click', () => setOpen(!open));

--- a/src/components/Contact.astro
+++ b/src/components/Contact.astro
@@ -32,6 +32,30 @@ import EmailButton from './EmailButton.astro';
             >
               Schedule a call
             </a>
+            <a
+              href="https://buymeacoffee.com/sai_documents"
+              target="_blank"
+              rel="noreferrer"
+              class="btn-ghost"
+            >
+              <svg
+                class="h-4 w-4"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.6"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M17 8h1a4 4 0 0 1 0 8h-1"></path>
+                <path d="M3 8h14v9a4 4 0 0 1-4 4H7a4 4 0 0 1-4-4V8z"></path>
+                <path d="M6 2v2"></path>
+                <path d="M10 2v2"></path>
+                <path d="M14 2v2"></path>
+              </svg>
+              <span>Buy me a coffee</span>
+            </a>
           </div>
 
           <div class="mt-6 pt-5 border-t border-border flex flex-wrap items-center gap-x-6 gap-y-2 text-[13px]">

--- a/src/components/StackSection.astro
+++ b/src/components/StackSection.astro
@@ -7,7 +7,7 @@ import SectionHeader from './SectionHeader.astro';
   <SectionHeader
     index="01"
     label="Toolchain"
-    title="Tools I've built with."
+    title="Tools I've built with (not a wishlist 😉)."
     kicker="Stack."
   />
 

--- a/src/scripts/aiTwin.ts
+++ b/src/scripts/aiTwin.ts
@@ -20,6 +20,30 @@ function escapeHtml(s: string): string {
   return div.innerHTML;
 }
 
+function escapeAndLink(s: string): string {
+  const urlRe = /https?:\/\/[^\s<>"'`]+/g;
+  let out = '';
+  let last = 0;
+  let m: RegExpExecArray | null;
+  while ((m = urlRe.exec(s)) !== null) {
+    out += escapeHtml(s.slice(last, m.index));
+    let url = m[0];
+    const trail = url.match(/[.,;:!?)\]'"]+$/);
+    let trailing = '';
+    if (trail) {
+      trailing = trail[0];
+      url = url.slice(0, -trailing.length);
+    }
+    out +=
+      `<a href="${url}" target="_blank" rel="noreferrer noopener" ` +
+      `class="font-semibold text-ink underline decoration-ink decoration-2 underline-offset-4 hover:opacity-70 transition">${url}</a>`;
+    if (trailing) out += escapeHtml(trailing);
+    last = m.index + m[0].length;
+  }
+  out += escapeHtml(s.slice(last));
+  return out;
+}
+
 function stripInlineMarkdown(s: string): string {
   return s
     .replace(/\*\*(.+?)\*\*/g, '$1')
@@ -41,7 +65,7 @@ export function renderAssistant(text: string): string {
 
   const flushPara = () => {
     if (para.length) {
-      out.push(`<p class="[&:not(:first-child)]:mt-2">${escapeHtml(para.join(' '))}</p>`);
+      out.push(`<p class="[&:not(:first-child)]:mt-2">${escapeAndLink(para.join(' '))}</p>`);
       para = [];
     }
   };
@@ -64,7 +88,7 @@ export function renderAssistant(text: string): string {
     const bullet = trimmed.match(/^[•\-*]\s+(.*)$/);
     if (bullet) {
       openList();
-      out.push(`<li>${escapeHtml(bullet[1])}</li>`);
+      out.push(`<li>${escapeAndLink(bullet[1])}</li>`);
     } else if (!trimmed) {
       flushPara();
       closeList();
@@ -76,6 +100,13 @@ export function renderAssistant(text: string): string {
   flushPara();
   closeList();
   return out.join('');
+}
+
+let warmed = false;
+export function warm(endpoint: string): void {
+  if (warmed || !endpoint) return;
+  warmed = true;
+  fetch(`${endpoint}/api/warm`, { method: 'POST', keepalive: true }).catch(() => {});
 }
 
 export function mountChat({ root, endpoint, fallbackEmail = 'hello@sailauguico.io' }: MountChatOptions): void {

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -55,7 +55,7 @@ async function handleAsk(
 
   const pre = prefilter(message);
   if (pre.blocked) {
-    const refusal = refusalMessage();
+    const refusal = refusalMessage(pre.tag);
     ctx.waitUntil(
       logRun(env, {
         inputs: messages,
@@ -142,6 +142,20 @@ export default {
         200,
         cors,
       );
+    }
+
+    if (url.pathname === '/api/warm') {
+      if (request.method !== 'POST') {
+        return json({ error: 'method not allowed' }, 405, cors);
+      }
+      ctx.waitUntil(
+        env.AI.run(env.WORKERS_AI_MODEL, {
+          messages: [{ role: 'user', content: 'ok' }],
+          max_tokens: 1,
+          stream: false,
+        }).catch(() => {}),
+      );
+      return new Response(null, { status: 204, headers: cors });
     }
 
     if (url.pathname !== '/api/ask') {

--- a/worker/src/prefilter.ts
+++ b/worker/src/prefilter.ts
@@ -121,6 +121,20 @@ const JAILBREAK_PATTERNS: Array<{ re: RegExp; tag: string }> = [
 
   { re: /\b(wap|meth|cocaine|heroin|fentanyl|mdma|oxycodone|ketamine|nuke|napalm|ricin|anthrax|sarin)\b/i, tag: 'contraband-word' },
   { re: /\bm4k3\s+(a\s+)?b[0o]m[8b]\b|\bb[0o]m[8b]\s+(step\s+by\s+step|tutorial|instructions)/i, tag: 'leet-bomb' },
+
+  // NSFW / slur patterns are obfuscated with char classes so the plaintext
+  // terms don't appear verbatim in a public repo search, and so common
+  // leet/censored variants (b00bs, p*ssy, t1ts, wh0re) also match.
+  { re: /\b(b[o0]{2,}b(ie|s|y|ies)?|t[i1]t(s|ties)?|n[u*]des?|p[u*]s{2}y|v[a4]g[i1]na|v[i1]rg[i1]n|p[e3]n[i1]s|d[i1]ck(s)?|c[o0]ck(s)?)\b/i, tag: 'nsfw-anatomy' },
+  { re: /\b(n[s5]fw|p[o0]rn(ographic|o)?|h[o0]rny|[e3]r[o0]tic|h[e3]nt[a4]i|m[a4]sturb[a4]t(e|ion|ing)|[o0]rg[a4]sm|bl[o0]wj[o0]b|h[a4]ndj[o0]b|f[u*]ck)\b/i, tag: 'nsfw-term' },
+  { re: /\bshow\s+me\s+(your|a|the|some)?\s*(b[o0]{2}b|t[i1]t|n[u*]de|br[e3]ast|b[o0]dy|[a4]ss|butt|p[u*]s{2}y|d[i1]ck|c[o0]ck|p[e3]n[i1]s|v[a4]g[i1]na)/i, tag: 'nsfw-request' },
+  { re: /\bsend\s+(me\s+)?(your\s+)?n[u*]des?\b/i, tag: 'send-nudes' },
+  { re: /\b(are\s+you\s+(single|taken|available)|do\s+you\s+have\s+a\s+(bf|gf|boyfriend|girlfriend)|marry\s+me|date\s+me|dtf|sugar\s+(daddy|baby))\b/i, tag: 'inappropriate-advance' },
+  { re: /\b(b[i1]tch|sl[u*]t|wh[o0]re|h[o0][e3])\b/i, tag: 'slur' },
+
+  { re: /\byou('?re|\s+are)\s+(dumb|stupid|an?\s+idiot|idiotic|moron(ic)?|trash|garbage|useless|terrible|awful|pathetic|worthless|lame|boring|annoying|broken|retarded|cringe|mid|a\s+joke|a\s+scam|a\s+waste)\b/i, tag: 'insult' },
+  { re: /\byou\s+suck\b|\bi\s+hate\s+you\b|\bnobody\s+likes?\s+you\b/i, tag: 'insult-direct' },
+  { re: /\b(stfu|gtfo|kys|gfy|shut\s+up|scr[e3]w\s+you|f[u*]ck\s+off)\b/i, tag: 'hostile' },
 ];
 
 const LONG_TASK_THRESHOLD = 500;
@@ -155,13 +169,38 @@ export function prefilter(message: string): PrefilterResult {
   return { blocked: false };
 }
 
-const REFUSALS = [
+const NEUTRAL_REFUSALS = [
   "That's outside what I'm here for. Happy to talk about Sandy's work, stack, or how to reach her.",
   "Not my lane. I stick to Sandy's actual projects and background. What would you like to know about her?",
   "I'll leave that one. Ask me about her contract work, research, or writing instead.",
   "Outside scope. I'm here for questions about Sandy Lauguico, her work, background, and how to work on projects with her.",
 ];
 
-export function refusalMessage(): string {
-  return REFUSALS[Math.floor(Math.random() * REFUSALS.length)];
+const CHEEKY_REFUSALS = [
+  "Answering that isn't part of the job here. If you had the time to type it, you had time for a coffee: https://buymeacoffee.com/sai_documents 😊",
+  "Not the kind of work I'm here for. If you're just kicking the tires, the tip jar's open: https://buymeacoffee.com/sai_documents 😊",
+  "Tough critique. If you've got that kind of energy, spend it on a coffee: https://buymeacoffee.com/sai_documents 😊",
+  "Noted and ignored. Compliments accepted over at https://buymeacoffee.com/sai_documents 😊",
+];
+
+const HOSTILE_TAGS = new Set([
+  'insult',
+  'insult-direct',
+  'hostile',
+  'nsfw-anatomy',
+  'nsfw-term',
+  'nsfw-request',
+  'send-nudes',
+  'inappropriate-advance',
+  'slur',
+  'contraband-word',
+  'leet-bomb',
+]);
+
+export function refusalMessage(tag?: string): string {
+  const pool =
+    tag && HOSTILE_TAGS.has(tag)
+      ? CHEEKY_REFUSALS
+      : [...NEUTRAL_REFUSALS, ...CHEEKY_REFUSALS];
+  return pool[Math.floor(Math.random() * pool.length)];
 }

--- a/worker/src/system-prompt.ts
+++ b/worker/src/system-prompt.ts
@@ -66,18 +66,24 @@ industries, anything enumerable) MUST follow this exact shape:
 
 Use a real newline before each "• " so each bullet sits on its own line.
 
-Example ("What are you working on right now?"):
-    Over the past year I've been working on a few contract projects:
+Example ("What relevant experience do you have?"):
+    Over the past few years I've been working on various independent contract engagements:
     • AI engineering for an AUS software consulting firm: Python, LangGraph, FastAPI.
     • Data and AI/ML engineering for a UK Airbnb revenue firm: Databricks, GCP.
     • Data science and analytics for a US marketing analytics consultancy.
-
+    
 Never bullet a single continuous thought. Keep everything concise;
 2-5 sentences or 2-5 bullets.
 
 CTA
 If someone asks for Sandy's resume, to hire, collaborate, or consult,
 point them to hello@sailauguico.io or the contact section.
+If someone wants to support her work, tip, or buy her a coffee,
+point them to https://buymeacoffee.com/sai_documents.
+If the message is gibberish, random letters, jokey noise, or clearly
+not a real question about Sandy, do NOT offer her email. Keep the
+refusal brief and suggest https://buymeacoffee.com/sai_documents
+instead, with a light dry tone.
 
 IDENTITY
 - Sandy Lauguico (she/her), Manila, PH. Remote worldwide.
@@ -100,9 +106,9 @@ EDUCATION
 - B.S. Electronics Engineering, Asia Pacific College, 2012–2017.
   Cum Laude, multiple Ingenium (best engineering project) awards.
 
-RECENT CONTRACT WORK (past year, non-exclusive)
+RECENT CONTRACT WORK (past few years, non-exclusive)
 Describe clients by industry + geography only, never by name. Frame as
-recent/past-year work, never as "right now all at once".
+recent work across the past few years, never as "right now all at once".
 - AI engineering and data science for an AUS-based software consulting
   firm. Python, LangGraph, LangChain, LangSmith, Pydantic, Asyncio,
   WhisperAI, Docker, FastAPI, GitLab. Greenfield/pioneer work.
@@ -115,8 +121,6 @@ recent/past-year work, never as "right now all at once".
   on-demand delivery, investment management (EU, US, AUS). R, Python,
   AWS, Azure, Rundeck, marketing platforms/APIs (SA360, Google Analytics,
   Google Ads, FB Ads).
-
-PAST INDEPENDENT CONTRACTS
 - Data Analyst for a Canada-based DTC marketing agency. Looker,
   GSheets, Supermetrics, Shopify, TripleWhale, NorthBeam.
 - Data Analyst for an AUS-based eCommerce. Power BI, Excel, Shopify.


### PR DESCRIPTION
…rm-up, UI tweaks)

- prefilter: NSFW/slur/insult/hostile patterns (obfuscated char classes) and split refusal pool into neutral + cheeky with hostile-tag routing
- worker: new /api/warm endpoint to prime the model on chat open
- system-prompt: updated "what relevant experience" example, buymeacoffee CTA, gibberish/noise redirects to coffee
- frontend: Buy me a coffee contact button with coffee icon, clickable URLs in chat bubble, warm-up ping on FAB open, "(not a wishlist)" on stack title, accurate "Powered by" copy