### PR TITLE
FIX: read PUBLIC_GA_ID from vars (Variable) instead of secrets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,7 @@ jobs:
         run: npm run build
         env:
           PUBLIC_AI_ENDPOINT: ${{ secrets.PUBLIC_AI_ENDPOINT }}
-          PUBLIC_GA_ID: ${{ secrets.PUBLIC_GA_ID }}
+          PUBLIC_GA_ID: ${{ vars.PUBLIC_GA_ID }}
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
The GA Measurement ID is public-by-design and was added under the Variables tab in repo settings, not Secrets. Workflow now reads from ${{ vars.PUBLIC_GA_ID }} so the build picks it up at compile time.