### PR TITLE
FIX: use arguments object in gtag shim so gtag.js processes commands

### DIFF
--- a/src/scripts/analytics.ts
+++ b/src/scripts/analytics.ts
@@ -6,7 +6,7 @@ const DISABLE_KEY = `ga-disable-${GA_ID}` as const;
 
 declare global {
   interface Window {
-    dataLayer: unknown[];
+    dataLayer: IArguments[];
     gtag: (...args: unknown[]) => void;
   }
 }
@@ -17,8 +17,14 @@ function loadGtag(): void {
   (window as unknown as Record<string, unknown>)[DISABLE_KEY] = false;
 
   window.dataLayer = window.dataLayer || [];
-  window.gtag =
-    window.gtag ?? ((...args: unknown[]) => window.dataLayer.push(args));
+  if (!window.gtag) {
+    // gtag.js consumes IArguments-shaped entries from dataLayer; pushing
+    // an Array (e.g. via rest params) silently fails to register commands.
+    window.gtag = function gtag() {
+      // eslint-disable-next-line prefer-rest-params
+      window.dataLayer.push(arguments as unknown as IArguments);
+    };
+  }
 
   if (document.getElementById(SCRIPT_ID)) return;
 


### PR DESCRIPTION
shim defined gtag as an arrow function pushing rest-args (Array) to dataLayer. gtag.js consumes IArguments-shaped entries, so it silently ignored our js/config commands -- no cookies set, no hits fired, even though the script loaded successfully.

Switch to the canonical Google snippet pattern:
  function gtag(){dataLayer.push(arguments)}

Verified end-to-end with Playwright: toast shows, allow click sets _ga cookies, collect request fires (204), revoke clears cookies and suppresses subsequent hits.